### PR TITLE
fixed too long filename for system

### DIFF
--- a/spelt/__init__.py
+++ b/spelt/__init__.py
@@ -149,8 +149,18 @@ def download_photo(output, photo):
     :type photo: dict
     :return: 0 if errors, 1 if OK.
     """
-    target_filename = u'%s%s' % (photo.get('title') or photo['id'], path.splitext(photo['url'])[1])
+
+    # to keep neuteral order and avoid overwriting when few photos have the same description
+    basename = u'%s%s' % (photo['id'],  u'_' + photo.get('title') if photo.get('title') else '')
+    # Filesystem naming limitation to avoid error 255 bytes for ext3,ext4
+    if sys.getsizeof(basename) > 245:
+        basename = photo['id']
+
+    target_filename = u'%s%s' % (basename, path.splitext(photo['url'])[1])
     photo_filename = path.join(output, target_filename)
+    if path.isfile(photo_filename):
+        logger.debug(u'Image %s already exist. Skipped.', basename)
+        return 1
     logger.debug(u'Begin download image %s to %s', photo['url'], photo_filename)
     try:
         r = requests.get(photo['url'], stream=True)


### PR DESCRIPTION
Hi! 
I tried to use your application and faced few minor issues.
Please have a look to my pull request.
I'm not very familiar with Python so do not hesitate to give some feedback how to do it more elegant.

Thank you for your job I have downloaded everything that I needed.

Fixes list:
1. too long filename for system
2. overriding file when more than one photos have the same description
3. prevent downloading already existing images

Sample error:
```
[2017-02-27 23:19:46,477][Spelt][ERROR   ]  [Errno 36] File name too long: u'/home/denis/Pictures/vkontakte/new/no!/\u0426\u0435 \u0442\u0435\u043a\u0441\u0442-"\u0440\u0438\u0431\u0430", \u0449\u043e \u0432\u0438\u043a\u043e\u0440\u0438\u0441\u0442\u043e\u0432\u0443\u0454\u0442\u044c\u0441\u044f \u0432 \u0434\u0440\u0443\u043a\u0430\u0440\u0441\u0442\u0432\u0456 \u0442\u0430 \u0434\u0438\u0437\u0430\u0439\u043d\u0456. lorem ipsum \u0454, \u0444\u0430\u043a\u0442\u0438\u0447\u043d\u043e, \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442\u043d\u043e\u044e "\u0440\u0438\u0431\u043e\u044e" \u0430\u0436 \u0437 xvi \u0441\u0442\u043e\u0440\u0456\u0447\u0447\u044f, \u043a\u043e\u043b\u0438 \u043d\u0435\u0432\u0456\u0434\u043e\u043c\u0438\u0439 \u0434\u0440\u0443\u043a\u0430\u0440 \u0432\u0437\u044f\u0432 \u0448\u0440\u0438\u0444\u0442\u043e\u0432\u0443 \u0433\u0440\u0430\u043d\u043a\u0443 \u0442\u0430 \u0441\u043a\u043b\u0430\u0432 \u043d\u0430 \u043d\u0456\u0439 \u043f\u0456\u0434\u0431\u0456\u0440\u043a\u0443 \u0437\u0440\u0430\u0437\u043a\u0456\u0432 \u0448\u0440\u0438\u0444\u0442\u0456\u0432..jpg'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/spelt/__init__.py", line 160, in download_photo
    with open(photo_filename, 'wb') as fd:

```